### PR TITLE
Update ItemMap.java

### DIFF
--- a/src/main/java/me/RockinChaos/itemjoin/item/ItemAnimation.java
+++ b/src/main/java/me/RockinChaos/itemjoin/item/ItemAnimation.java
@@ -123,7 +123,7 @@ public class ItemAnimation {
         while (it.hasNext()) {
             final String name = it.next();
             final Integer delay = StringUtils.returnInteger(ItemHandler.getDelayFormat(name));
-            ticks = ticks + Objects.requireNonNullElse(delay, 180);
+            ticks = ticks + (delay != null ? delay : 180);
             this.AnimateTask(player, it.hasNext(), name, null, null, null, null, null, ticks, 0);
         }
     }
@@ -140,7 +140,7 @@ public class ItemAnimation {
         while (it.hasNext()) {
             final List<String> lore = it.next();
             final Integer delay = StringUtils.returnInteger(ItemHandler.getDelayFormat(lore.get(0)));
-            ticks = ticks + Objects.requireNonNullElse(delay, 180);
+            ticks = ticks + (delay != null ? delay : 180);
             this.AnimateTask(player, it.hasNext(), null, lore, null, null, null, null, ticks, position);
             position++;
         }
@@ -157,7 +157,7 @@ public class ItemAnimation {
         while (it.hasNext()) {
             final String mat = it.next();
             final Integer delay = StringUtils.returnInteger(ItemHandler.getDelayFormat(mat));
-            ticks = ticks + Objects.requireNonNullElse(delay, 180);
+            ticks = ticks + (delay != null ? delay : 180);
             this.AnimateTask(player, it.hasNext(), null, null, mat, null, null, null, ticks, 0);
         }
     }
@@ -170,7 +170,7 @@ public class ItemAnimation {
     private void pagesTasks(final Player player) {
         long ticks = 0;
         final Integer delay = StringUtils.returnInteger(ItemHandler.getDelayFormat(this.dynamicPages.get(0)));
-        ticks = ticks + Objects.requireNonNullElse(delay, 180);
+        ticks = ticks + (delay != null ? delay : 180);
         this.AnimateTask(player, false, null, null, null, null, null, this.dynamicPages, ticks, 0);
     }
 
@@ -185,7 +185,7 @@ public class ItemAnimation {
         while (it.hasNext()) {
             final String owner = it.next();
             final Integer delay = StringUtils.returnInteger(ItemHandler.getDelayFormat(owner));
-            ticks = ticks + Objects.requireNonNullElse(delay, 180);
+            ticks = ticks + (delay != null ? delay : 180);
             this.AnimateTask(player, it.hasNext(), null, null, null, owner, null, null, ticks, 0);
         }
     }
@@ -201,7 +201,7 @@ public class ItemAnimation {
         while (it.hasNext()) {
             final String texture = it.next();
             final Integer delay = StringUtils.returnInteger(ItemHandler.getDelayFormat(this.dynamicTextures.get(0)));
-            ticks = ticks + Objects.requireNonNullElse(delay, 180);
+            ticks = ticks + (delay != null ? delay : 180);
             this.AnimateTask(player, it.hasNext(), null, null, null, null, texture, null, ticks, 0);
         }
     }

--- a/src/main/java/me/RockinChaos/itemjoin/item/ItemMap.java
+++ b/src/main/java/me/RockinChaos/itemjoin/item/ItemMap.java
@@ -1498,7 +1498,7 @@ public class ItemMap implements Cloneable {
      * @return The Probability.
      */
     public Integer getProbability() {
-        return Objects.requireNonNullElse(this.probability, 0);
+        return (this.probability != null) ? this.probability : 0;
     }
 
     /**


### PR DESCRIPTION
Fix 1.8 bug NoSuchMethodException

# Description

In 1.8.8 servers this exception is displayed in console:
```
[14:47:12] [Server thread/WARN]: [ItemJoin] Task #23 for ItemJoin v6.0.3-RELEASE-b18 generated an exception
java.lang.NoSuchMethodError: java.util.Objects.requireNonNullElse(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
	at me.RockinChaos.itemjoin.item.ItemMap.getProbability(ItemMap.java:1486) ~[?:?]
	at me.RockinChaos.itemjoin.item.ItemDesigner.setProbability(ItemDesigner.java:721) ~[?:?]
	at me.RockinChaos.itemjoin.item.ItemDesigner.registerItems(ItemDesigner.java:119) ~[?:?]
```