### PR TITLE
Update: spigot.version 1.21.7-R0.1-SNAPSHOT → 1.21.8-R0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <chaoscore.version>1.1.3-SNAPSHOT</chaoscore.version>
-        <spigot.version>1.21.7-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.21.8-R0.1-SNAPSHOT</spigot.version>
 
         <authlib.version>1.5.21</authlib.version>
         <worldguard.version>7.0.4-SNAPSHOT</worldguard.version>


### PR DESCRIPTION
# Description

Update: spigot.version from 1.21.7-R0.1-SNAPSHOT to 1.21.8-R0.1-SNAPSHOT.

This change adds support for the latest Minecraft Java version (1.21.8). It prevents the error message that previously appeared when starting the plugin on this new version:

```log
[19:14:11] [Craft Scheduler Thread - 4 - ItemJoin/ERROR]: [ItemJoin_ERROR] Detected an unsupported version of Minecraft, expected: 1.21.7 or older!
[19:14:11] [Craft Scheduler Thread - 4 - ItemJoin/ERROR]: [ItemJoin_ERROR] Attempting to run in NMS compatibility mode...
[19:14:11] [Craft Scheduler Thread - 4 - ItemJoin/ERROR]: [ItemJoin_ERROR] Things may not work as expected, please check for plugin updates.
[19:14:11] [Craft Scheduler Thread - 4 - ItemJoin/INFO]: [ItemJoin] Hooked into { WorldGuard, PlaceholderAPI
```

Fixes # (no specific issue, adds support for the new Minecraft version)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The plugin was compiled using Maven with my IDE and tested on my server running the latest Paper version (1.21.8). Everything works correctly.

**Test Configuration**:
* Server version: Paper 1.21.8
* Java version: (please specify, e.g. Java 17)
* Plugin configurations: default configuration, no changes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes